### PR TITLE
ReOrder option created for current orders

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Order do
   permit_params :status, :total_price, :notes, :name, :address, :phone, :delivery_date, :company_id, :taken_by,
-    order_items_attributes: [:id, :product_id, :quantity, :quantity_dispatched]
+    order_items_attributes: [:id, :product_id, :quantity, :to_dispatch]
 
   index do
     selectable_column

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -68,6 +68,26 @@ class OrdersController < ApplicationController
     end
   end
 
+  def order_again
+    @old_order = current_user.orders.find(params[:id])
+    @order = @old_order.dup
+    @order.status = "Ordered"
+    @order.created_at = nil
+    @order.updated_at = nil
+    @old_order.order_items.each do |oi|
+      noi = oi.dup
+      noi.created_at = nil
+      noi.updated_at = nil
+      noi.quantity_dispatched = nil
+      @order.order_items << noi
+    end
+    (10 - @old_order.order_items.count).times do
+      @order.order_items << OrderItem.new
+    end
+    authorize @order
+    render :new
+  end
+
   private
 
   def order_params

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -4,15 +4,12 @@ class Order < ApplicationRecord
   belongs_to :company
   before_create :update_status
   accepts_nested_attributes_for :order_items, allow_destroy: true, reject_if: lambda { |oi| oi[:product_id].blank? }
-  # accepts_nested_attributes_for :order_items, allow_destroy: true
   validates :order_items, presence: :true
   after_update :update_total
   after_create :update_total
   before_create :update_total
   before_save :update_total
   before_save :check_quantity_match
-  # before_update :check_quantity_match
-
 
   def total_quantity
     self.order_items.map { |oi| oi.quantity }.sum
@@ -22,9 +19,6 @@ class Order < ApplicationRecord
   def calculate_total
     self.order_items.map { |item| item.total }.sum
   end
-
-  # @order = Order.find(params[:id])
-  # @order_items = @order.order_items
 
   private
   # Methods should always be private if they will be used within a model onlu

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -6,4 +6,13 @@ class OrderItem < ApplicationRecord
   def total
     self.product ? self.quantity.to_i * self.product.price : 0.0
   end
+  #Retrives the quantity to dispatch
+  def to_dispatch
+    self.quantity - self.quantity_dispatched
+  end
+  #Updates the new retrieved quantity value with the remaining to be dispatched to close the order and mark as disptached
+  def to_dispatch=(q)
+    self.quantity_dispatched += q.to_i
+  end
+
 end

--- a/app/policies/order_policy.rb
+++ b/app/policies/order_policy.rb
@@ -29,4 +29,8 @@ class OrderPolicy < ApplicationPolicy
     true
   end
 
+  def order_again?
+    true
+  end
+
 end

--- a/app/views/admin/orders/_show_partial.html.erb
+++ b/app/views/admin/orders/_show_partial.html.erb
@@ -13,7 +13,8 @@
     <th>Quantity</th>
     <th>Pack Size</th>
     <th>Total Price</th>
-    <th>Quantity Confirmed</th>
+    <th>Quantity Disptached</th>
+    <th>Quantity To Dispatch</th>
   </tr>
 <%= f.fields_for :order_items do |oi| %>
   <tr>
@@ -24,7 +25,8 @@
     <td><%= oi.object.quantity %></td>
     <td><%= oi.object.product.pack_size %></td>
     <td><%= number_to_currency oi.object.product.price * oi.object.quantity.to_i %></td>
-    <td><%= oi.number_field :quantity_dispatched %></td>
+    <td><%= oi.object.quantity_dispatched %></td>
+    <td><%= oi.number_field :to_dispatch %></td>
     <%= oi.hidden_field :product_id %>
   </tr>
 <% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -24,6 +24,7 @@
   <% end %>
   <tr>
     <th><%= link_to "My Orders", orders_path, class: "btn btn-info" %></th>
+    <th><%= link_to "Order Again", reorder_path, class: "btn btn-info" %></th>
     <td><% if @order.status == "Ordered" %>
     <%= link_to "Edit Orders", edit_order_path(@order), class: "btn btn-warning" %>
     <% end %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
   resources :order_items
   resource :cart, only: [:show, :destroy, :create]
   resources :orders#, only: [:index, :show, :destroy, :new]
-
+  get '/order_again/:id', to: 'orders#order_again', as: 'reorder'
 end


### PR DESCRIPTION
- Users can reorder an existing order with the functionality to add new items
- View only Quantity dispatch field that shows quantity dispatched if the order is in Incomplete state
- New Quantity To Dispatch field where the user will input the remaining quantity to be dispatched
