### PR TITLE
Audit Gem was installed to trace back audits made on specific models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'activeadmin', github: 'activeadmin/activeadmin'
 gem 'inherited_resources', github: 'activeadmin/inherited_resources'
 gem 'coffee-rails', '~> 4.1', '>= 4.2.2'
 gem 'trackerific'
-
+gem 'audited', '~> 4.7'
 
 gem 'autoprefixer-rails'
 gem 'bootstrap-sass', '~> 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (8.0.0)
+    audited (4.7.1)
+      activerecord (>= 4.0, < 5.3)
     autoprefixer-rails (8.2.0)
       execjs
     babel-source (5.8.35)
@@ -288,6 +290,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin!
+  audited (~> 4.7)
   autoprefixer-rails
   bootstrap-sass (~> 3.3)
   coffee-rails (~> 4.1, >= 4.2.2)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -11,6 +11,7 @@ class Order < ApplicationRecord
   before_create :update_total
   before_save :update_total
   before_save :check_quantity_match
+  audited
 
   def total_quantity
     self.order_items.map { |oi| oi.quantity }.sum

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -2,6 +2,7 @@ class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :product, optional: :true
   validates :quantity, presence: :true
+  audited
 
   def total
     self.product ? self.quantity.to_i * self.product.price : 0.0

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,4 @@
 class Product < ApplicationRecord
   has_many :order_items
+  audited
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+  audited
 end

--- a/db/migrate/20180503134153_install_audited.rb
+++ b/db/migrate/20180503134153_install_audited.rb
@@ -1,0 +1,30 @@
+class InstallAudited < ActiveRecord::Migration[5.1]
+  def self.up
+    create_table :audits, :force => true do |t|
+      t.column :auditable_id, :integer
+      t.column :auditable_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
+      t.column :user_id, :integer
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :jsonb
+      t.column :version, :integer, :default => 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.column :created_at, :datetime
+    end
+
+    add_index :audits, [:auditable_type, :auditable_id], :name => 'auditable_index'
+    add_index :audits, [:associated_type, :associated_id], :name => 'associated_index'
+    add_index :audits, [:user_id, :user_type], :name => 'user_index'
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180502090050) do
+ActiveRecord::Schema.define(version: 20180503134153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,28 @@ ActiveRecord::Schema.define(version: 20180502090050) do
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
+  end
+
+  create_table "audits", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.jsonb "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
   create_table "companies", force: :cascade do |t|


### PR DESCRIPTION
Audit Gem is used to trace back audits made on specific models e.g. To trace back if the user has updated the order and and its content.