### PR TITLE
Search box is hidden by default, appears when click on search

### DIFF
--- a/app/admin/customers.rb
+++ b/app/admin/customers.rb
@@ -6,6 +6,8 @@ ActiveAdmin.register User, as: "Customer" do
   remove_filter :encrypted_password, :reset_password_token, :reset_password_sent_at, :remember_created_at,
                   :current_sign_in_at, :last_sign_in_at, :created_at, :updated_at, :admin
 
+  filter :company, as: :select, label: "Search by Company", prompt: "Select or Type", collection: Company.all.collect { |u| [u.name, u.id] },
+         input_html: { class: 'chosen-select2' }
   filter :email, as: :select, label: "Search by Email", prompt: "Select or Type", collection: User.all.collect { |u| [u.email] },
          input_html: { class: 'chosen-select2' }
   filter :forname, as: :select, label: "Search by Forname", prompt: "Select or Type", collection: User.all.collect { |u| u.forname },
@@ -36,6 +38,7 @@ ActiveAdmin.register User, as: "Customer" do
     column :admin
     column :company
     actions
+
   end
 
   form do |f|
@@ -55,6 +58,11 @@ ActiveAdmin.register User, as: "Customer" do
       f.input :password
     end
     f.actions
+  end
+
+  action_item :view, priority: 0 do
+    link_to 'Search', class: "search"
+
   end
 
 end

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -35,3 +35,23 @@ $ ->
     $('.user_selector').hide()
     $('.company-' + value).show()
     return
+
+
+$ ->
+  hiddenSidebar = ->
+    $('#sidebar').hide()
+    $('.admin_customers #collection_selection').width '130%'
+    return
+
+  showSideBar = ->
+    hiddenSidebar()
+    grabSearchBtn = $('.action_items .action_item a').first().on('click', (evt) ->
+      evt.preventDefault()
+      $('#sidebar').show()
+      $('.admin_customers #collection_selection').width '100%'
+      return
+    )
+    return
+  showSideBar()
+
+


### PR DESCRIPTION
In admin the search box for customers is hidden by default but will only appear when clicking on the search button at the top of the page.

This auto hides when carrying out a search.