### PR TITLE
Name + nil issues have now been fixed for names

### DIFF
--- a/app/admin/consignments.rb
+++ b/app/admin/consignments.rb
@@ -11,10 +11,10 @@ ActiveAdmin.register Consignment do
     end
     column :tracking_no
     column "Admin", :user do |u|
-      link_to (u.user.forname + " " + u.user.surname), admin_staff_path(u.user)
+      link_to (u.user.forname.to_s + " " + u.user.surname.to_s), admin_staff_path(u.user)
     end
     column "Customer", :user do |u|
-      link_to (u.order.user.forname + " " + u.order.user.surname), admin_customer_path(u.order.user)
+      link_to (u.order.user.forname.to_s + " " + u.order.user.surname.to_s), admin_customer_path(u.order.user)
     end
     column "Order #", sortable: :order_id do |o|
       link_to o.order.id, admin_order_path(o.order.id)

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -15,7 +15,7 @@ ActiveAdmin.register Order do
     end
     column :created_at
     column "Customer", :user_id do |u|
-      link_to u.user.forname + " " + u.user.surname, admin_customer_path(u.user_id)
+      link_to u.user.forname.to_s + " " + u.user.surname.to_s, admin_customer_path(u.user_id)
     end
     column :company
     column "Admin Assigned", :taken_by


### PR DESCRIPTION
Name issues in Admin Orders and Consignments have now been fixed. The issue was related to either surname or forname being blank and it was not able to add them so converting to string helped resolved that