### PR TITLE
Facebook/Gmail style browser tab notifications for new orders

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register_page "Dashboard" do
   content title: proc{ I18n.t("active_admin.dashboard") } do
     columns do
       column do
-        panel "Recent Orders" do
+        panel "Recent Orders", class: "orders" do
           table_for Order.where(status: ["Ordered", "Incomplete"]).order("id desc").limit(10) do
             column("Order#") { |order| link_to(order.id, admin_order_path(order)) }
             column("Order Date") { |order| order.created_at }

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -53,4 +53,16 @@ $ ->
     return
   showSideBar()
 
+# This shows the number of outstanding or new orders in chrome tab
+$ ->
+  title = document.title
+  countNewOrders = ->
+    countOrders = $('.orders tbody tr').length
+    newTitle = '(' + countOrders + ') ' + title
+    document.title = newTitle
+    return
 
+  changeTitle = ->
+    setInterval countNewOrders, 5000
+    return
+  $('.orders tbody tr').onload = changeTitle()


### PR DESCRIPTION
For all new orders, admins will be able to see the total count on the browser tab when on admin dashboard page