### PR TITLE
Incomplete Quantity now migrated to the order items table

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -79,7 +79,7 @@ ActiveAdmin.register Order do
           @new_consignment_for_incmp = Consignment.create!(user: current_user, order: @order, shipped_at: Time.now, tracking_no: "", status: @order.status)
           @new_consignment_for_incmp.order.order_items.each do |oi|
             nci = @new_consignment_for_incmp.consignment_items.new
-            nci.quantity = oi.quantity_dispatched
+            nci.quantity = oi.incomplete_quantity
             nci.order_item_id = oi.id
             @new_consignment_for_incmp.consignment_items << nci
           end
@@ -89,7 +89,7 @@ ActiveAdmin.register Order do
           @new_consignment_for_disptch = Consignment.create!(user: current_user, order: @order, shipped_at: Time.now, tracking_no: "", status: @order.status)
           @new_consignment_for_disptch.order.order_items.each do |ci|
             nci = @new_consignment_for_disptch.consignment_items.new
-            nci.quantity = ci.quantity_dispatched
+            nci.quantity = ci.incomplete_quantity
             nci.order_item_id = ci.id
             @new_consignment_for_disptch.consignment_items << nci
           end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -13,6 +13,7 @@ class OrderItem < ApplicationRecord
   end
   #Updates the new retrieved quantity value with the remaining to be dispatched to close the order and mark as disptached
   def to_dispatch=(q)
+    self.incomplete_quantity = q
     self.quantity_dispatched.nil? ? self.quantity_dispatched = q : self.quantity_dispatched += q.to_i
   end
 

--- a/app/views/admin/consignments/_show_partial.html.erb
+++ b/app/views/admin/consignments/_show_partial.html.erb
@@ -10,6 +10,7 @@
     <th>Product Desc</th>
     <th>Requested</th>
     <th>Dispatched</th>
+    <th>Remaining</th>
     <th>Status</th>
     <th>Date Dispatched</th>
     <th>Price</th>
@@ -23,6 +24,7 @@
     <td><%= ci.order_item.product.description %></td>
     <td><%= ci.order_item.quantity %></td>
     <td><%= ci.quantity %></td>
+    <td><%= ci.order_item.to_dispatch %></td>
     <% if ci.consignment.status == "Incomplete" %>
     <td class="Incomplete"><%= ci.consignment.status.upcase %></td>
     <% else ci.consignment.status == "Dispatched" %>

--- a/db/migrate/20180711101710_add_incomplete_quantity_to_order_item.rb
+++ b/db/migrate/20180711101710_add_incomplete_quantity_to_order_item.rb
@@ -1,0 +1,5 @@
+class AddIncompleteQuantityToOrderItem < ActiveRecord::Migration[5.1]
+  def change
+    add_column :order_items, :incomplete_quantity, :integer
+  end
+end


### PR DESCRIPTION
Issue where quantity to dispatch within order item confirmation wasn't being saved and this was not being deducted from the stock change count. 

Resolved by migrating a new field to the order items table 'incomplete quantity' which holds the value of quantity thats being dispatched resulting in a fix. 